### PR TITLE
Remove unused macros settings button

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,19 +277,6 @@
       background-color: #c82333; /* Slightly darker red */
     }
 
-#macrosSettingsBtn {
-  background-color: var(--primary);
-  color: var(--text-color);
-  border: none;
-  padding: 4px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 12px;
-  transition: background-color 0.3s ease;
-}
-#macrosSettingsBtn:hover {
-  background-color: var(--primary-dark);
-}
 
 #goBackBtn {
   margin-bottom: 20px;
@@ -798,10 +785,7 @@
   </div>
 
 <div id="macroTab" class="tab-content" style="position: relative; padding: 20px;">
-  <!-- Settings Button, top right, only shown on Macros tab -->
-<button id="macrosSettingsBtn" onclick="openMacroSettings()" style="position: absolute; top: 8px; right: 8px; display: none; font-size: 0.8rem; padding: 4px 8px;">
-    ⚙️ Settings
-  </button>
+
 
   <!-- Main Macros Content -->
   <div id="macrosMainContent" style="max-width: 600px; margin: 0 auto;">
@@ -1251,10 +1235,6 @@ function showTab(tabName) {
   }
   activeTab = tab;
 
-  const settingsBtn = document.getElementById('macrosSettingsBtn');
-  if (settingsBtn) {
-    settingsBtn.style.display = tabName === 'macroTab' ? 'block' : 'none';
-  }
 
   switch (tabName) {
     case 'macroTab':
@@ -2816,18 +2796,12 @@ function openMacroSettings() {
   // Hide the main macros content and reveal the settings view
   document.getElementById('macrosMainContent').style.display = 'none';
   document.getElementById('macrosSettingsContent').style.display = 'block';
-  // Hide the settings button so only the "Go Back" button shows
-  const btn = document.getElementById('macrosSettingsBtn');
-  if (btn) btn.style.display = 'none';
 }
 
 function closeMacroSettings() {
   // Return to the main macros view
   document.getElementById('macrosSettingsContent').style.display = 'none';
   document.getElementById('macrosMainContent').style.display = 'block';
-  // Restore the settings button visibility
-  const btn = document.getElementById('macrosSettingsBtn');
-  if (btn) btn.style.display = 'block';
 }
 
 // expose helpers for inline handlers
@@ -4028,18 +4002,12 @@ function openMacroSettings() {
   // Hide the main macros content and reveal the settings view
   document.getElementById('macrosMainContent').style.display = 'none';
   document.getElementById('macrosSettingsContent').style.display = 'block';
-  // Hide the settings button so only the "Go Back" button shows
-  const btn = document.getElementById('macrosSettingsBtn');
-  if (btn) btn.style.display = 'none';
 }
 
 function closeMacroSettings() {
   // Return to the main macros view
   document.getElementById('macrosSettingsContent').style.display = 'none';
   document.getElementById('macrosMainContent').style.display = 'block';
-  // Restore the settings button visibility
-  const btn = document.getElementById('macrosSettingsBtn');
-  if (btn) btn.style.display = 'block';
 }
 
 // expose helpers for inline handlers


### PR DESCRIPTION
## Summary
- drop macros settings button and related CSS
- remove logic showing/hiding the button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d72ae07e483238f128006f54976b2